### PR TITLE
Abstract & Scope of the specification

### DIFF
--- a/dataset-spec.html
+++ b/dataset-spec.html
@@ -46,8 +46,11 @@
 </head>
 <body>
 <section id="abstract">
-  <p>
-  </p>
+    <h2>Scope and Abstract</h2>
+      <p>The dataset specification provides a way to store multiple quads in a so-called dataset. Similar to the <strong>Interface Specification: RDF Representation</strong> (RDFJS Specification), this is a low-level specification that provides only essential methods for working with multiple quads. High-level interfaces that work with quads can and should be using libraries that implement this interface.</p>
+      <p>The specification itself consists of a core-part that is the base for all other functions defined.</p>
+      <p>Low-level methods are using explicit parameters that cannot be omitted.</p>
+      <p>Additional high-level interfaces are outside of the scope of this specification and should be defined elsewhere.</p>
 </section>
 
 <section id="sotd">

--- a/dataset-spec.html
+++ b/dataset-spec.html
@@ -46,8 +46,8 @@
 </head>
 <body>
 <section id="abstract">
-    <h2>Scope and Abstract</h2>
-      <p>The dataset specification provides a way to store multiple quads in a so-called dataset. Similar to the <strong>Interface Specification: RDF Representation</strong> (RDFJS Specification), this is a low-level specification that provides only essential methods for working with multiple quads. High-level interfaces that work with quads can and should be using libraries that implement this interface.</p>
+    <h2>Abstract</h2>
+      <p>The scope of this specification is to provide a way to store multiple quads in a so-called dataset. Similar to the <strong>Interface Specification: RDF Representation</strong> (RDFJS Specification), this is a low-level specification that provides only essential methods for working with multiple quads. High-level interfaces that work with quads can and should be using libraries that implement this interface.</p>
       <p>The specification itself consists of a core-part that is the base for all other functions defined.</p>
       <p>Low-level methods are using explicit parameters that cannot be omitted.</p>
       <p>Additional high-level interfaces are outside of the scope of this specification and should be defined elsewhere.</p>


### PR DESCRIPTION
There was no abstract and scope defined in the specification so far. This introduces the scope of the specification and clarifies the distinction between low-level and high-level interfaces. I hope this helps resolving issues #4, #8  and #10.