### PR TITLE
reduced DatasetCore to a minimal set of methods

### DIFF
--- a/dataset-spec.html
+++ b/dataset-spec.html
@@ -69,11 +69,8 @@
       readonly attribute unsigned long  size;
       Dataset                           add (Quad quad);
       Dataset                           delete (Quad quad);
-      boolean                           equals (Dataset other);
       boolean                           has (Quad quad);
       Dataset                           match (optional Term subject, optional Term predicate, optional Term object, optional Term graph);
-      any                               reduce (QuadReduceIteratee iteratee, optional any initialValue);
-      sequence&lt;Quad&gt;                    toArray ();
 
       iterable&lt;Quad&gt;;
     };
@@ -106,12 +103,6 @@
     <p>This method returns the dataset instance it was called on.</p>
 
     <p>
-      <dfn>equals</dfn>
-    </p>
-    <p>Returns true if the current instance contains the same graph structure as the given dataset.</p>
-    <p>Blank Nodes will be normalized.</p>
-
-    <p>
       <dfn>has</dfn>
     </p>
     <p>Determines whether a dataset includes a certain quad, returning true or false as appropriate.</p>
@@ -132,24 +123,6 @@
      <p>This method implements AND functionality, so only quads matching all of the given non-null arguments will be included in the result.</p>
     <p>Note: this method always returns a new <a>DatasetCore</a>, even if that dataset contains no quads.</p>
     <p>Note: <a>Dataset</a>s represent Sets of <code>Quad</code>s, the order is arbitrary, so this method may result in differing results when called repeatedly.</p>
-
-    <p>
-      <dfn>reduce</dfn>
-    </p>
-    <p>
-      This method calls the <code>iteratee</code> for each <code>quad</code> of the <a>DatasetCore</a>.
-      The first time the <code>iteratee</code> is called, the <code>accumulator</code> value is the <code>initialValue</code> or, if not given, equals to the first quad of the Dataset.
-      The return value of the <code>iteratee</code> is used as <code>accumulator</code> value for the next calls.
-    </p>
-    <p>This method returns the return value of the last <code>iteratee</code> call.</p>
-    <p>Note: This method is aligned with Array.prototype.reduce() in ECMAScript-262.</p>
-
-    <p>
-      <dfn>toArray</dfn>
-    </p>
-    <p>Returns the set of quads within the dataset as a host language native sequence, for example an Array in ECMAScript-262.</p>
-    <p>Note: a sequence in [WEBIDL] is passed by value, not by reference.</p>
-    <p>Note: the order of the quads within the returned sequence is arbitrary, since a <a>DatasetCore</a> is an unordered set.</p>
   </section>
 
   <section data-dfn-for="Dataset">
@@ -160,17 +133,20 @@
       Dataset                           addAll ((Dataset or sequence&lt;Quad&gt;) quads);
       Dataset                           deleteMatches (optional Term subject, optional Term predicate, optional Term object, optional Term graph);
       Dataset                           difference (Dataset other);
+      boolean                           equals (Dataset other);
       boolean                           every (QuadFilterIteratee iteratee);
       Dataset                           filter (QuadFilterIteratee iteratee);
       void                              forEach (QuadRunIteratee iteratee);
       Promise&lt;Dataset&gt;                  import (Stream stream);
       Dataset                           intersection (Dataset other);
       Dataset                           map (QuadMapIteratee iteratee);
+      any                               reduce (QuadReduceIteratee iteratee, optional any initialValue);
       boolean                           some (QuadFilterIteratee iteratee);
+      sequence&lt;Quad&gt;                    toArray ();
       String                            toCanonical ();
       Stream                            toStream ();
       String                            toString ();
-       Dataset                           union (Dataset quads);
+      Dataset                           union (Dataset quads);
     };
     </pre>
 
@@ -205,6 +181,12 @@
       <dfn>difference</dfn>
     </p>
     <p>Returns a new dataset that contains alls quads from the current dataset, not included in the given dataset.</p>
+
+    <p>
+      <dfn>equals</dfn>
+    </p>
+    <p>Returns true if the current instance contains the same graph structure as the given dataset.</p>
+    <p>Blank Nodes will be normalized.</p>
 
     <p>
       <dfn>every</dfn>
@@ -243,11 +225,29 @@
     <p>Returns a new dataset containing all quads returned by applying <code>iteratee</code> to each quad in the current dataset.</p>
 
     <p>
+      <dfn>reduce</dfn>
+    </p>
+    <p>
+      This method calls the <code>iteratee</code> for each <code>quad</code> of the <a>DatasetCore</a>.
+      The first time the <code>iteratee</code> is called, the <code>accumulator</code> value is the <code>initialValue</code> or, if not given, equals to the first quad of the Dataset.
+      The return value of the <code>iteratee</code> is used as <code>accumulator</code> value for the next calls.
+    </p>
+    <p>This method returns the return value of the last <code>iteratee</code> call.</p>
+    <p>Note: This method is aligned with Array.prototype.reduce() in ECMAScript-262.</p>
+
+    <p>
       <dfn>some</dfn>
     </p>
     <p>Existential quantification method, tests whether some quads in the dataset pass the test implemented by the provided <code>iteratee</code>.</p>
     <p>This method immediately returns boolean true once a quad that passes the test is found.</p>
     <p>Note: this method is aligned with Array.prototype.some() in ECMAScript-262.</p>
+
+    <p>
+      <dfn>toArray</dfn>
+    </p>
+    <p>Returns the set of quads within the dataset as a host language native sequence, for example an Array in ECMAScript-262.</p>
+    <p>Note: a sequence in [WEBIDL] is passed by value, not by reference.</p>
+    <p>Note: the order of the quads within the returned sequence is arbitrary, since a <a>DatasetCore</a> is an unordered set.</p>
 
     <p>
       <dfn>toCanonical</dfn>


### PR DESCRIPTION
As discussed in #18 this PR moves `equals`, `reduce` and `toArray` from `DatasetCore` to `Dataset`.