### PR TITLE
added DatasetCoreFactory

### DIFF
--- a/dataset-spec.html
+++ b/dataset-spec.html
@@ -122,7 +122,7 @@
     <h3><dfn>DatasetCoreFactory</dfn> interface</h3>
 
     <pre class="idl">
-    interface DatasetCoreFactory : DataFactory {
+    interface DatasetCoreFactory {
       DatasetCore dataset (optional sequence&lt;Quad&gt; quads);
     };
     </pre>

--- a/dataset-spec.html
+++ b/dataset-spec.html
@@ -128,10 +128,11 @@
     </pre>
 
     <p>
-      <dfn>dataset</dfn>
+      <code>DatasetCoreFactory</code> provides a <code>dataset</code> method to create instances of <code>DatasetCore</code>.
     </p>
+
     <p>
-      <code>DatasetCoreFactory</code> extends the <a href="http://rdf.js.org/#datafactory-interface">DataFactory</a> interface by a <code>dataset</code> method to create instances of <code>DatasetCore</code>.
+      <dfn>dataset</dfn>
     </p>
     <p>Returns a new dataset and imports all quads, if given.</p>
   </section>

--- a/dataset-spec.html
+++ b/dataset-spec.html
@@ -118,6 +118,24 @@
     <p>Note: <a>Dataset</a>s represent Sets of <code>Quad</code>s, the order is arbitrary, so this method may result in differing results when called repeatedly.</p>
   </section>
 
+  <section data-dfn-for="DatasetCoreFactory">
+    <h3><dfn>DatasetCoreFactory</dfn> interface</h3>
+
+    <pre class="idl">
+    interface DatasetCoreFactory : DataFactory {
+      DatasetCore dataset (optional sequence&lt;Quad&gt; quads);
+    };
+    </pre>
+
+    <p>
+      <dfn>dataset</dfn>
+    </p>
+    <p>
+      <code>DatasetCoreFactory</code> extends the <a href="http://rdf.js.org/#datafactory-interface">DataFactory</a> interface by a <code>dataset</code> method to create instances of <code>DatasetCore</code>.
+    </p>
+    <p>Returns a new dataset and imports all quads, if given.</p>
+  </section>
+
   <section data-dfn-for="Dataset">
     <h3><dfn>Dataset</dfn> interface</h3>
 


### PR DESCRIPTION
This PR fixes #20 by adding a `DatasetCoreFactory` interface.

In `DatasetFactory.dataset()` we have the `quads` argument defined like this: `optional (Dataset or sequence<Quad>) quads`. I replaced it with `optional sequence<Quad> quads` as the `DatasetCore` interface implements `sequence<Quad>`. Maybe we want to add it again to have it more explicit. I also added a short description for the interface. The rest is just an adapted copy of `DatasetFactory`.