### PR TITLE
added link to representation spec

### DIFF
--- a/dataset-spec.html
+++ b/dataset-spec.html
@@ -46,11 +46,15 @@
 </head>
 <body>
 <section id="abstract">
-    <h2>Abstract</h2>
-      <p>The scope of this specification is to provide a way to store multiple quads in a so-called dataset. Similar to the <strong>Interface Specification: RDF Representation</strong> (RDFJS Specification), this is a low-level specification that provides only essential methods for working with multiple quads. High-level interfaces that work with quads can and should be using libraries that implement this interface.</p>
-      <p>The specification itself consists of a core-part that is the base for all other functions defined.</p>
-      <p>Low-level methods are using explicit parameters that cannot be omitted.</p>
-      <p>Additional high-level interfaces are outside of the scope of this specification and should be defined elsewhere.</p>
+  <h2>Abstract</h2>
+  <p>
+    The scope of this specification is to provide a way to store multiple quads, as defined in the <a href="http://rdf.js.org/#quad-interface">Interface Specification: RDF Representation</a>, in a so-called dataset.
+    Similar to the <a href="http://rdf.js.org/">Interface Specification: RDF Representation</a>, this is a low-level specification that provides only essential methods for working with multiple quads.
+    High-level interfaces that work with quads can and should be using libraries that implement this interface.
+  </p>
+  <p>The specification itself consists of a core-part that is the base for all other functions defined.</p>
+  <p>Low-level methods are using explicit parameters that cannot be omitted.</p>
+  <p>Additional high-level interfaces are outside of the scope of this specification and should be defined elsewhere.</p>
 </section>
 
 <section id="sotd">


### PR DESCRIPTION
This PR adds a link to the RDF Representation spec, as discussed in #33. I checked some other specs if it is possible directly link from the interface to the external spec, but haven't found any examples. Adding it to the abstract looked like a good alternative.