### PR TITLE
allow null values in .match

### DIFF
--- a/dataset-spec.html
+++ b/dataset-spec.html
@@ -97,7 +97,7 @@
       Dataset                           add (Quad quad);
       Dataset                           delete (Quad quad);
       boolean                           has (Quad quad);
-      Dataset                           match (optional Term subject, optional Term predicate, optional Term object, optional Term graph);
+      Dataset                           match (optional Term? subject, optional Term? predicate, optional Term? object, optional Term? graph);
 
       iterable&lt;Quad&gt;;
     };


### PR DESCRIPTION
Originally the discussion about nullable values in `.match` started in an [Representation Task Force Issue](https://github.com/rdfjs/representation-task-force/issues/139), but it's also relevant for us. There is a slight difference between `undefined` and `null` in WebIDL. `optional ` allows `undefined` values, `?` postfix to the type allows `null` see [Nullable types in the WebIDL spec](https://www.w3.org/TR/WebIDL-1/#idl-nullable-type). I think both should be accepted.