### PR TITLE
add dataset-spec team to code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rdfjs/dataset-spec


### PR DESCRIPTION
This will add the @rdfjs/data-model-spec team to the [code owners](https://help.github.com/articles/about-code-owners/). Code owners are automatically added to the reviewers for each PR.