### PR TITLE
fixed links to data model specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,8 +71,8 @@
 <section id="abstract">
   <h2>Abstract</h2>
   <p>
-    The scope of this specification is to provide a way to store multiple quads, as defined in the <a href="http://rdf.js.org/#quad-interface">Interface Specification: RDF Representation</a>, in a so-called dataset.
-    Similar to the <a href="http://rdf.js.org/">Interface Specification: RDF Representation</a>, this is a low-level specification that provides only essential methods for working with multiple quads.
+    The scope of this specification is to provide a way to store multiple quads, as defined in the <a href="http://rdf.js.org/data-model-spec/#quad-interface">RDF/JS: Data model specification</a>, in a so-called dataset.
+    Similar to the <a href="http://rdf.js.org/data-model-spec/">RDF/JS: Data model specification</a>, this is a low-level specification that provides only essential methods for working with multiple quads.
     High-level interfaces that work with quads can and should be using libraries that implement this interface.
   </p>
   <p>The specification itself consists of a core-part that is the base for all other functions defined.</p>


### PR DESCRIPTION
This PR fixes the links to the data model specification, which has a new location in rdf.js.org.