### PR TITLE
Clarify .toString()

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
       <dfn>toString</dfn>
     </p>
     <p>Returns an N-Quads string representation of the dataset.</p>
-    <p>No normalization is done beforehand, so the results for the same quads may vary based on the Dataset implementation.</p>
+    <p>No prior normalization is required, therefore the results for the same quads may vary depending on the Dataset implementation.</p>
 
     <p>
       <dfn>union</dfn>


### PR DESCRIPTION
```diff
-<p>No normalization is done beforehand, so the results for the same quads may vary based on the Dataset implementation.</p>
+<p>No prior normalization is required, therefore the results for the same quads may vary depending on the Dataset implementation.</p>
```

Two reasons for this PR:

1. *No normalization is done beforehand* can be interpreted as: *implementers should not normalize in `.toString`*. I think the point is that normalization is not required, not that it should not be done.
2. *No normalization […], so the results may vary* could mean that the goal of not normalizing is to return different results. This change makes it clearer that the varying nature of the result is more of a consequence of not normalizing than the reason not to normalize.

https://raw.githack.com/rdfjs/dataset-spec/e91c864c9b75d2c64fc4ef8fcea9bd9314e0d994/index.html