### PR TITLE
QuadReduceIteratee returns the accumulator

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,7 +381,7 @@
 
     <pre class="idl">
     interface QuadReduceIteratee {
-      void run (any accumulator, Quad quad, Dataset dataset);
+      any run (any accumulator, Quad quad, Dataset dataset);
     };
     </pre>
 


### PR DESCRIPTION
This makes the IDL consistent with the descriptions of `QuadReduceIteratee` and `Reduce`:

> A callable function that can be executed on an accumulator and quad and **returns a new accumulator**.

This contradicts the IDL specifying it as `void`. According to the `reduce` definition:

> The return value of the `iteratee` is used as `accumulator` value for the next calls.